### PR TITLE
fix: update .dockerignore to include essential build files for Docker

### DIFF
--- a/kairos/.dockerignore
+++ b/kairos/.dockerignore
@@ -1,9 +1,22 @@
+# IMPORTANT: Files needed for Docker build (use ! to include)
+!package.json
+!bun.lock
+!tsconfig.json
+!tsconfig.build.json
+!bunfig.toml
+!build.ts
+!src/
+!vite.config.ts
+!tailwind.config.js
+!postcss.config.js
+!index.html
+
 # Dependencies
 node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-bun.lockb
+# bun.lockb - commented out to allow bun.lock in Docker builds
 
 # Runtime data
 pids
@@ -36,7 +49,7 @@ jspm_packages/
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 
-# TypeScript cache
+# TypeScript cache (but keep tsconfig files - see top of file)
 *.tsbuildinfo
 
 # Optional npm cache directory


### PR DESCRIPTION
Fixed Docker build error where package.json was not found during COPY step. Added explicit inclusions for critical build files that were being excluded.

Changes:
- Add explicit inclusions (!package.json, !bun.lock, !tsconfig.json, etc.)
- Comment out bun.lockb exclusion that interfered with bun.lock* pattern
- Add clarifying comments to prevent future build issues

This resolves the build error: "failed to calculate checksum: /package.json not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)