### PR TITLE
fix: disable Twitter search to avoid rate limits on Free tier

### DIFF
--- a/kairos/src/character.ts
+++ b/kairos/src/character.ts
@@ -67,10 +67,12 @@ export const character: ExtendedCharacter = {
     TWITTER_MAX_TWEET_LENGTH: '280',
 
     // Interaction settings for engagement
-    TWITTER_SEARCH_ENABLE: 'true',
-    TWITTER_INTERACTION_INTERVAL_MIN: '30',
-    TWITTER_INTERACTION_INTERVAL_MAX: '60',
-    TWITTER_MAX_INTERACTIONS_PER_RUN: '5',
+    // DISABLED: Twitter Free tier has extremely limited API access (1 request)
+    // Enable only if you have Twitter Basic tier ($100/mo) or higher
+    TWITTER_SEARCH_ENABLE: 'false',
+    TWITTER_INTERACTION_INTERVAL_MIN: '360',  // 6 hours (increased from 30 min to avoid rate limits)
+    TWITTER_INTERACTION_INTERVAL_MAX: '720',  // 12 hours (increased from 60 min)
+    TWITTER_MAX_INTERACTIONS_PER_RUN: '1',    // Reduced from 5 to minimize API calls
 
     // Timeline algorithm for quality engagement
     TWITTER_TIMELINE_ALGORITHM: 'weighted',


### PR DESCRIPTION
Twitter Free tier only allows 1 API request, causing immediate 429 rate limit errors when search was enabled. Disabled TWITTER_SEARCH_ENABLE and adjusted interaction intervals to prevent API exhaustion.

## Changes Made

- Set TWITTER_SEARCH_ENABLE to 'false' (was 'true')
- Increased TWITTER_INTERACTION_INTERVAL_MIN from 30 to 360 minutes (6 hours)
- Increased TWITTER_INTERACTION_INTERVAL_MAX from 60 to 720 minutes (12 hours)
- Reduced TWITTER_MAX_INTERACTIONS_PER_RUN from 5 to 1
- Added comments explaining Twitter API tier limitations

## Impact

✅ Prevents 429 rate limit errors from search API
✅ Posting functionality still works (uses different API limits) ✅ Can re-enable search if upgraded to Basic tier ($100/mo, 10k requests)

## Error Fixed
```
error: Request failed with code 429
x-rate-limit-limit: 1
x-rate-limit-remaining: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings Adjustments**
  * Twitter search functionality disabled
  * Twitter interaction intervals extended to reduce frequency
  * Maximum interactions per cycle limited to one

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->